### PR TITLE
build: enhance kimi-cli commands support in agents.ts

### DIFF
--- a/packages/skill-core/src/agents.ts
+++ b/packages/skill-core/src/agents.ts
@@ -165,8 +165,10 @@ export const builtInAgents = defineAgents({
   },
   "kimi-cli": {
     label: "Kimi Code CLI",
-    skillsDir: universalProjectSkillsDir,
-    globalSkillsDir: join(configHome, "agents/skills"),
+    skillsDir: ".kimi/skills",
+    globalSkillsDir: join(home, ".kimi/skills"),
+    commandsDir: ".kimi/commands",
+    globalCommandsDir: join(home, ".kimi/commands"),
     detectInstalled: () => existsSync(join(home, ".kimi")),
   },
   "kiro-cli": {


### PR DESCRIPTION
## Summary

Enhance \kimi-cli\ agent configuration in \packages/skill-core/src/agents.ts\ to properly support Kimi Code CLI's commands and skills directory conventions.

## Changes

- **skillsDir**: changed from \universalProjectSkillsDir\ () to brand-specific 
- **globalSkillsDir**: changed from  to  to align with Kimi CLI's actual paths
- **commandsDir**: added  (Kimi CLI supports project-level commands directory)
- **globalCommandsDir**: added  (Kimi CLI supports global commands directory)

## Verification

- [x] Checked \kimi-cli\ configuration in \packages/skill-core/src/agents.ts\
- [x] Confirmed Kimi Code CLI supports commands/skills directory mode
- [x] Added \commandsDir\ and \globalCommandsDir\
- [x] Verified \skillsDir\ and \globalSkillsDir\ paths match Kimi CLI actual paths
- [x] \supported_agents\ list (defaultSyncAgents + aliases) already includes \kimi-cli\

Closes #78