### PR TITLE
build: verify and fix global devops skills installation flow

### DIFF
--- a/scripts/dev-workflow.sh
+++ b/scripts/dev-workflow.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Unified DevOps workflow script
+# Provides install, verify, update, remove, hooks subcommands
+# Uses skill-spark CLI when available, falls back to standalone installers
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+DEVOPS_DIR="$PROJECT_DIR/skills/devops"
+
+# Resolve skill-spark binary
+CLI=""
+if command -v skill-spark &>/dev/null; then
+  CLI="skill-spark"
+elif [ -f "$PROJECT_DIR/dist/index.js" ]; then
+  CLI="node $PROJECT_DIR/dist/index.js"
+elif command -v bun &>/dev/null && [ -f "$PROJECT_DIR/packages/skill-cli/src/index.ts" ]; then
+  CLI="bun run $PROJECT_DIR/packages/skill-cli/src/index.ts"
+fi
+
+usage() {
+    cat <<EOF
+DevOps Workflow Script
+
+Usage: $0 {install|verify|update|remove|hooks} [options]
+
+Commands:
+  install [--scope system|project] [--agent <name>] [--yes]
+  verify  [--scope system|project] [--agent <name>]
+  update  [--scope system|project] [--agent <name>] [--yes]
+  remove  [--scope system|project] [--agent <name>] [--yes]
+  hooks
+
+Options:
+  --scope system|project   Installation scope (default: project)
+  --agent <name>           Target agent (claude-code, kimi, codex, opencode, trae)
+  --yes                    Auto-confirm prompts
+
+Examples:
+  $0 install --scope system --agent codex
+  $0 install --agent codex --yes
+  $0 verify --scope system
+  $0 update
+  $0 remove --scope system --agent codex --yes
+  $0 hooks
+EOF
+}
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+CMD="$1"
+shift
+
+SCOPE="project"
+AGENT=""
+YES=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scope)
+            SCOPE="$2"
+            shift 2
+            ;;
+        --agent)
+            AGENT="$2"
+            shift 2
+            ;;
+        --yes)
+            YES=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option '$1'" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+SKILLS="git-workflow local-workflow github-cli-skill gh-create-release scanning-for-secrets"
+
+run_with_cli() {
+    if [ -n "$CLI" ]; then
+        return 0
+    fi
+    return 1
+}
+
+resolve_scope_flag() {
+    if [ "$SCOPE" = "system" ]; then
+        echo "--global"
+    else
+        echo ""
+    fi
+}
+
+resolve_agent_flag() {
+    if [ -n "$AGENT" ]; then
+        echo "--agent $AGENT"
+    else
+        echo ""
+    fi
+}
+
+resolve_yes_flag() {
+    if [ "$YES" = true ]; then
+        echo "--yes"
+    else
+        echo ""
+    fi
+}
+
+case "$CMD" in
+    install)
+        if run_with_cli; then
+            # shellcheck disable=SC2086
+            $CLI add skills/devops $(resolve_scope_flag) $(resolve_agent_flag) $(resolve_yes_flag)
+        else
+            echo "skill-spark not found. Build first: bun run build"
+            echo "Falling back to standalone installer..."
+            if [ "$SCOPE" = "system" ]; then
+                SYSTEM_FLAG="--system"
+            else
+                SYSTEM_FLAG="--project"
+            fi
+            AGENT_FLAG=""
+            if [ -n "$AGENT" ]; then
+                AGENT_FLAG="--agent $AGENT"
+            fi
+            # shellcheck disable=SC2086
+            exec "$DEVOPS_DIR/dev-workflow-install.sh" $SYSTEM_FLAG $AGENT_FLAG
+        fi
+        ;;
+    verify)
+        echo "Verifying devops skills installation..."
+        FOUND=0
+        for skill in $SKILLS; do
+            if [ "$SCOPE" = "system" ]; then
+                # Check common global directories
+                for dir in "$HOME/.config/agents/skills" "$HOME/.claude/skills" "$HOME/.codex/skills" "$HOME/.config/opencode/skills" "$HOME/.trae/skills"; do
+                    if [ -e "$dir/$skill" ]; then
+                        echo "  [OK] $skill -> $dir/$skill"
+                        FOUND=$((FOUND + 1))
+                        break
+                    fi
+                done
+            else
+                if [ -e "./.agents/skills/$skill" ]; then
+                    echo "  [OK] $skill -> ./.agents/skills/$skill"
+                    FOUND=$((FOUND + 1))
+                elif [ -e "./.claude/skills/$skill" ]; then
+                    echo "  [OK] $skill -> ./.claude/skills/$skill"
+                    FOUND=$((FOUND + 1))
+                elif [ -e "./.trae/skills/$skill" ]; then
+                    echo "  [OK] $skill -> ./.trae/skills/$skill"
+                    FOUND=$((FOUND + 1))
+                fi
+            fi
+        done
+        echo ""
+        echo "Verified: $FOUND / 5 skills"
+        if [ "$FOUND" -lt 5 ]; then
+            exit 1
+        fi
+        ;;
+    update)
+        if run_with_cli; then
+            # shellcheck disable=SC2086
+            $CLI update $SKILLS $(resolve_scope_flag) $(resolve_agent_flag) $(resolve_yes_flag)
+        else
+            echo "Error: skill-spark is required for update. Build first: bun run build" >&2
+            exit 1
+        fi
+        ;;
+    remove)
+        if run_with_cli; then
+            # shellcheck disable=SC2086
+            $CLI remove $SKILLS $(resolve_scope_flag) $(resolve_agent_flag) $(resolve_yes_flag)
+        else
+            echo "Error: skill-spark is required for remove. Build first: bun run build" >&2
+            exit 1
+        fi
+        ;;
+    hooks)
+        if [ ! -d ".git/hooks" ]; then
+            echo "Error: Not a git repository." >&2
+            exit 1
+        fi
+        HOOK_SRC="$DEVOPS_DIR/git-workflow/hooks"
+        for hook in prepare-commit-msg post-commit; do
+            if [ -f "$HOOK_SRC/$hook" ]; then
+                cp "$HOOK_SRC/$hook" ".git/hooks/$hook"
+                chmod +x ".git/hooks/$hook"
+                echo "Installed .git/hooks/$hook"
+            fi
+        done
+        ;;
+    *)
+        echo "Error: Unknown command '$CMD'" >&2
+        usage
+        exit 1
+        ;;
+esac

--- a/skills/devops/README.md
+++ b/skills/devops/README.md
@@ -32,15 +32,8 @@ scripts/dev-workflow.sh remove --scope system --agent codex
 Windows PowerShell / PowerShell 7：
 
 ```powershell
-pwsh -File scripts/dev-workflow.ps1 install -Agent codex
-pwsh -File scripts/dev-workflow.ps1 verify -Agent codex
-pwsh -File scripts/dev-workflow.ps1 update -Agent codex
-pwsh -File scripts/dev-workflow.ps1 remove -Agent codex
-
-# system/global level for Codex
-pwsh -File scripts/dev-workflow.ps1 install -Scope system -Agent codex
-pwsh -File scripts/dev-workflow.ps1 verify -Scope system -Agent codex
-pwsh -File scripts/dev-workflow.ps1 remove -Scope system -Agent codex
+pwsh -File skills/devops/dev-workflow-install.ps1 -System -Agent codex
+pwsh -File skills/devops/dev-workflow-install.ps1 -Project -Agent codex
 ```
 
 Codex project level 会安装到 `.agents/skills`；Codex system/global level 会安装到 `$CODEX_HOME/skills`，未设置 `CODEX_HOME` 时为 `~/.codex/skills`。
@@ -76,7 +69,7 @@ python3 .agents/skills/local-workflow/scripts/orchestrate.py finish
 只有在确实需要自动提醒或 commit 事件日志时，再安装 hook：
 
 ```bash
-scripts/dev-workflow.sh hooks --agent claude-code
+scripts/dev-workflow.sh hooks
 ```
 
 注意：Codex 不执行 Claude Code 的 `.claude/settings.json` hook。Codex 的控制入口是 `AGENTS.md`、已安装的 `.agents/skills/*/SKILL.md`，以及上面的显式 CLI。

--- a/skills/devops/dev-workflow-install.ps1
+++ b/skills/devops/dev-workflow-install.ps1
@@ -5,7 +5,7 @@
     Installs all dev-workflow related skills.
 
 .DESCRIPTION
-    Installs: github-cli-skill, gh-create-release, git-workflow, local-workflow
+    Installs: github-cli-skill, gh-create-release, git-workflow, local-workflow, scanning-for-secrets
 
 .PARAMETER System
     Install to system directories
@@ -14,7 +14,7 @@
     Install to current project directory
 
 .PARAMETER Agent
-    Target specific agent (claude-code, kimi, codex, opencode, trae, trae-solo)
+    Target specific agent (claude-code, kimi, codex, opencode, trae)
 
 .PARAMETER Hooks
     Also install git hooks (git-workflow only)
@@ -54,6 +54,7 @@ $Skills = @(
     "gh-create-release"
     "git-workflow"
     "local-workflow"
+    "scanning-for-secrets"
 )
 
 function Write-ColorOutput {
@@ -86,30 +87,28 @@ function Get-SystemTargetDirs {
         "" {
             $dirs += Join-Path $homePath ".config\agents\skills"
             $dirs += Join-Path $homePath ".claude\skills"
-            $dirs += Join-Path $homePath ".kimi\skills"
             $dirs += Join-Path $homePath ".codex\skills"
-            $dirs += Join-Path $homePath ".opencode\skills"
+            $dirs += Join-Path $homePath ".config\opencode\skills"
             $dirs += Join-Path $homePath ".trae\skills"
         }
         "claude-code" {
             $dirs += Join-Path $homePath ".claude\skills"
         }
         "kimi" {
-            $dirs += Join-Path $homePath ".kimi\skills"
             $dirs += Join-Path $homePath ".config\agents\skills"
         }
         "codex" {
             $dirs += Join-Path $homePath ".codex\skills"
         }
         "opencode" {
-            $dirs += Join-Path $homePath ".opencode\skills"
+            $dirs += Join-Path $homePath ".config\opencode\skills"
         }
-        { $_ -in "trae", "trae-solo" } {
+        { $_ -in "trae" } {
             $dirs += Join-Path $homePath ".trae\skills"
         }
         default {
             Write-ErrorMsg "Error: Unknown agent '$Agent'"
-            Write-Host "Supported agents: claude-code, kimi, codex, opencode, trae, trae-solo"
+            Write-Host "Supported agents: claude-code, kimi, codex, opencode, trae"
             exit 1
         }
     }

--- a/skills/devops/dev-workflow-install.sh
+++ b/skills/devops/dev-workflow-install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Dev Workflow Combined Installer (macOS / Linux)
-# Installs all dev-workflow related skills: github-cli-skill, gh-create-release, git-workflow, local-workflow
+# Installs all dev-workflow related skills: github-cli-skill, gh-create-release, git-workflow, local-workflow, scanning-for-secrets
 #
 # Usage: ./dev-workflow-install.sh [--system | --project] [--agent <name>] [--hooks]
 #
 # Options:
 #   --system        Install to system skill directories (default: ~/.config/agents/skills/)
 #   --project       Install to current project directory (./.agents/skills/)
-#   --agent <name>  Target specific agent (claude-code, kimi, codex, opencode, trae, trae-solo)
+#   --agent <name>  Target specific agent (claude-code, kimi, codex, opencode, trae)
 #   --hooks         Also install git hooks (git-workflow only)
 #   -h, --help      Show this help message
 #
@@ -32,6 +32,7 @@ SKILLS=(
     "gh-create-release"
     "git-workflow"
     "local-workflow"
+    "scanning-for-secrets"
 )
 
 RED='\033[0;31m'
@@ -50,7 +51,7 @@ Usage: ./dev-workflow-install.sh [--system | --project] [--agent <name>] [--hook
 Options:
   --system        Install to system directories (~/.config/agents/skills/)
   --project       Install to current project directory (./.agents/skills/)
-  --agent <name>  Target specific agent (claude-code, kimi, codex, opencode, trae, trae-solo)
+  --agent <name>  Target specific agent (claude-code, kimi, codex, opencode, trae)
   --hooks         Also install git hooks (git-workflow only)
   -h, --help      Show this help message
 
@@ -157,30 +158,28 @@ get_system_target_dirs() {
         "")
             dirs+=("$HOME/.config/agents/skills")
             dirs+=("$HOME/.claude/skills")
-            dirs+=("$HOME/.kimi/skills")
             dirs+=("$HOME/.codex/skills")
-            dirs+=("$HOME/.opencode/skills")
+            dirs+=("$HOME/.config/opencode/skills")
             dirs+=("$HOME/.trae/skills")
             ;;
         claude-code)
             dirs+=("$HOME/.claude/skills")
             ;;
         kimi)
-            dirs+=("$HOME/.kimi/skills")
             dirs+=("$HOME/.config/agents/skills")
             ;;
         codex)
             dirs+=("$HOME/.codex/skills")
             ;;
         opencode)
-            dirs+=("$HOME/.opencode/skills")
+            dirs+=("$HOME/.config/opencode/skills")
             ;;
-        trae|trae-solo)
+        trae)
             dirs+=("$HOME/.trae/skills")
             ;;
         *)
             echo -e "${RED}Error: Unknown agent '$TARGET_AGENT'${NC}" >&2
-            echo "Supported agents: claude-code, kimi, codex, opencode, trae, trae-solo" >&2
+            echo "Supported agents: claude-code, kimi, codex, opencode, trae" >&2
             exit 1
             ;;
     esac

--- a/skills/devops/dev-workflow-symlink-install.sh
+++ b/skills/devops/dev-workflow-symlink-install.sh
@@ -7,7 +7,7 @@
 # Options:
 #   --system          Install to system skill directories
 #   --project         Install to current project directory
-#   --agent <name>    Target specific agent (claude-code, kimi, codex, opencode, trae, trae-solo)
+#   --agent <name>    Target specific agent (claude-code, kimi, codex, opencode, trae)
 #                     If omitted, installs to all supported agents.
 #   --hooks           Also install git hooks (git-workflow only, project mode only)
 #   -h, --help        Show this help message
@@ -49,7 +49,7 @@ Usage: ./dev-workflow-symlink-install.sh [--system | --project] [--agent <name>]
 Options:
   --system          Install to system directories
   --project         Install to current project directory
-  --agent <name>    Target specific agent (claude-code, kimi, codex, opencode, trae, trae-solo)
+  --agent <name>    Target specific agent (claude-code, kimi, codex, opencode, trae)
   --hooks           Also install git hooks (git-workflow only)
   -h, --help        Show this help message
 
@@ -98,30 +98,28 @@ get_system_target_dirs() {
         "")
             echo "$HOME/.config/agents/skills"
             echo "$HOME/.claude/skills"
-            echo "$HOME/.kimi/skills"
             echo "$HOME/.codex/skills"
-            echo "$HOME/.opencode/skills"
+            echo "$HOME/.config/opencode/skills"
             echo "$HOME/.trae/skills"
             ;;
         claude-code)
             echo "$HOME/.claude/skills"
             ;;
         kimi)
-            echo "$HOME/.kimi/skills"
             echo "$HOME/.config/agents/skills"
             ;;
         codex)
             echo "$HOME/.codex/skills"
             ;;
         opencode)
-            echo "$HOME/.opencode/skills"
+            echo "$HOME/.config/opencode/skills"
             ;;
-        trae|trae-solo)
+        trae)
             echo "$HOME/.trae/skills"
             ;;
         *)
             echo -e "${RED}Error: Unknown agent '$TARGET_AGENT'${NC}" >&2
-            echo "Supported agents: claude-code, kimi, codex, opencode, trae, trae-solo" >&2
+            echo "Supported agents: claude-code, kimi, codex, opencode, trae" >&2
             exit 1
             ;;
     esac


### PR DESCRIPTION
Fixes the global devops skills installation flow to align with skill-spark agent configuration.

## Changes

- **Fix agent global skill directories** to match skill-spark CLI agent config:
  - \+ opencode: ~/.config/opencode/skills (was ~/.opencode/skills)
  - \* kimi: ~/.config/agents/skills only (was also ~/.kimi/skills)
  - \- trae: remove invalid trae-solo alias
- **Add missing scanning-for-secrets** to dev-workflow-install.sh and dev-workflow-install.ps1
- **Create scripts/dev-workflow.sh** unified wrapper supporting install/verify/update/remove/hooks subcommands
- **Fix README** to reference correct scripts and fix hooks command syntax

Closes #76